### PR TITLE
refactor: single domain-vocabulary source, no scattered hardcoding

### DIFF
--- a/tests/test_vlm_drive.py
+++ b/tests/test_vlm_drive.py
@@ -316,3 +316,25 @@ class TestRealLoRAFormat(unittest.TestCase):
         records = json.loads(real.read_text(encoding="utf-8"))
         ok = sum(1 for t in records.values() if not validate(parse_text_sections(t, image="x")))
         self.assertGreaterEqual(ok / len(records), 0.8)
+
+
+class TestVocabularyConsistency(unittest.TestCase):
+    """categories.py is the single vocabulary source — these pin its invariants."""
+
+    def test_aliases_target_canonical_buckets(self):
+        from vlm_drive.categories import SURFACE_ALIASES, VEHICLE_CN, PEDESTRIAN_CN, SIGN_CN
+        buckets = set(VEHICLE_CN) | set(PEDESTRIAN_CN) | set(SIGN_CN)
+        for alias, target in SURFACE_ALIASES.items():
+            self.assertIn(target, buckets, f"alias {alias!r} targets unknown bucket {target!r}")
+
+    def test_buckets_derived_from_nuscenes_map(self):
+        from vlm_drive.categories import NUSCENES_CATEGORY_CN, VEHICLE_CN
+        self.assertEqual(
+            VEHICLE_CN,
+            tuple(n for k, n in NUSCENES_CATEGORY_CN.items() if k.startswith("vehicle.")),
+        )
+
+    def test_canonicalize_rejects_prose(self):
+        from vlm_drive.categories import canonicalize
+        self.assertEqual(canonicalize("车距离约为"), "")
+        self.assertEqual(canonicalize("三辆汽车里的汽车"), "小汽车")

--- a/vlm_drive/categories.py
+++ b/vlm_drive/categories.py
@@ -1,0 +1,66 @@
+"""Single source of the project's domain vocabulary.
+
+Everything that needs category words imports from here, so the vocabulary
+cannot drift between the GT builder, the parser, and the evaluator:
+
+- NUSCENES_CATEGORY_CN is the nuScenes -> Chinese display-name map the GT
+  text is generated from (mirrors 04_prepare_training_data.py);
+- VEHICLE_CN / PEDESTRIAN_CN / SIGN_CN are derived from it, not re-listed;
+- SURFACE_ALIASES maps the wording the fine-tuned model actually emits
+  (汽车/车辆/巴士/单车...) onto those canonical buckets. Observed in the
+  real lora_eval_results.json replies; extend here when new drift shows up.
+"""
+from __future__ import annotations
+
+NUSCENES_CATEGORY_CN: dict[str, str] = {
+    "vehicle.car": "小汽车",
+    "vehicle.truck": "卡车",
+    "vehicle.bus.rigid": "公交车",
+    "vehicle.motorcycle": "摩托车",
+    "vehicle.bicycle": "自行车",
+    "human.pedestrian.adult": "行人",
+    "movable_object.trafficcone": "交通锥",
+}
+
+# Derived buckets — do not edit by hand; add categories above instead.
+VEHICLE_CN: tuple[str, ...] = tuple(
+    name for key, name in NUSCENES_CATEGORY_CN.items() if key.startswith("vehicle.")
+)
+PEDESTRIAN_CN: tuple[str, ...] = tuple(
+    name for key, name in NUSCENES_CATEGORY_CN.items() if key.startswith("human.")
+)
+SIGN_CN: tuple[str, ...] = tuple(
+    name for key, name in NUSCENES_CATEGORY_CN.items() if key.startswith("movable_object.")
+)
+
+# Model-output wording -> canonical bucket (targets must exist in the buckets
+# above; enforced by tests/test_vlm_drive.py).
+SURFACE_ALIASES: dict[str, str] = {
+    "汽车": "小汽车",
+    "车辆": "小汽车",
+    "巴士": "公交车",
+    "单车": "自行车",
+    "锥桶": "交通锥",
+    "锥": "交通锥",
+    "路人": "行人",
+}
+
+
+def canonicalize(category: str) -> str:
+    """Return the canonical bucket name for a surface category, or ''."""
+    for canonical in (*VEHICLE_CN, *PEDESTRIAN_CN, *SIGN_CN):
+        if canonical in category:
+            return canonical
+    for alias, canonical in SURFACE_ALIASES.items():
+        if alias in category:
+            return canonical
+    return ""
+
+
+def is_object_category(category: str) -> bool:
+    """True when a counted 'category' names a real object, not prose.
+
+    Used by the parser to drop measurement noise (一辆车距离约为50米 -> the
+    numeral grammar grabs '车距离约为' as a category).
+    """
+    return canonicalize(category) != ""

--- a/vlm_drive/cli.py
+++ b/vlm_drive/cli.py
@@ -15,6 +15,7 @@ this CLI is the maintained path for everything downstream of a checkpoint.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -30,6 +31,17 @@ def _cmd_infer(args: argparse.Namespace) -> int:
     )
     analyzer.load_model()
     analyzer.analyze_folder(args.images, args.out, limit=args.limit)
+    return 0
+
+
+def _cmd_gt(args: argparse.Namespace) -> int:
+    from .gt import build_gt
+
+    gt = build_gt(args.nuscenes, args.images, min_visibility=args.min_visibility)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(gt, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"真值生成：{len(gt)} 张 -> {out}")
     return 0
 
 
@@ -57,6 +69,14 @@ def build_parser() -> argparse.ArgumentParser:
     infer.add_argument("--repair", type=int, default=1, help="json 模式解析失败后的重试次数（默认 1）")
     infer.add_argument("--limit", type=int, default=None, help="只处理前 N 张（调试用）")
     infer.set_defaults(func=_cmd_infer)
+
+    gt = sub.add_parser("gt", help="从本地 nuScenes 标注生成评估集真值（04 生成器格式）")
+    gt.add_argument("--nuscenes", required=True, help="nuScenes 表目录，如 data/v1.0-trainval")
+    gt.add_argument("--images", required=True, help="评估图片目录")
+    gt.add_argument("--out", required=True, help="输出 GT JSON 路径")
+    gt.add_argument("--min-visibility", type=int, default=1, choices=[1, 2, 3, 4],
+                    help="nuScenes 可见度门槛 1-4（默认 1=不过滤；4=只保留 80-100% 可见物体，最贴近前摄视野）")
+    gt.set_defaults(func=_cmd_gt)
 
     evaluate = sub.add_parser("evaluate", help="预测结果 vs nuScenes 标注的自动评分")
     evaluate.add_argument("--pred", required=True, help="预测结果 JSON（新版结构化记录或旧版裸文本均可）")

--- a/vlm_drive/evaluator.py
+++ b/vlm_drive/evaluator.py
@@ -23,12 +23,12 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from .categories import PEDESTRIAN_CN, SIGN_CN, VEHICLE_CN, canonicalize
 from .parsing import parse_ground_truth, parse_text_sections
 from .schema import SceneAnalysis, validate
 
-VEHICLE_BUCKET_WORDS = ("小汽车", "卡车", "公交车", "摩托车", "自行车")
-PEDESTRIAN_WORD = "行人"
-CONE_WORD = "交通锥"
+PEDESTRIAN_WORD = PEDESTRIAN_CN[0]
+CONE_WORD = SIGN_CN[0]
 
 
 def _as_analysis(record: Any, image: str) -> SceneAnalysis:
@@ -47,17 +47,16 @@ def _as_analysis(record: Any, image: str) -> SceneAnalysis:
 
 
 def _bucket_vehicles(counts: dict[str, int]) -> dict[str, int]:
+    """Bucket surface categories via the shared vocabulary (categories.py).
+
+    Direct bucket names match by substring; model drift (汽车/车辆/...) maps
+    through SURFACE_ALIASES inside canonicalize().
+    """
     bucketed: dict[str, int] = {}
     for category, count in counts.items():
-        for word in VEHICLE_BUCKET_WORDS:
-            if word in category:
-                bucketed[word] = bucketed.get(word, 0) + count
-                break
-        else:
-            # Generic wording the fine-tuned model uses ("三辆汽车") maps to
-            # the corresponding nuScenes bucket (vehicle.car -> 小汽车).
-            if "汽车" in category or "车辆" in category:
-                bucketed["小汽车"] = bucketed.get("小汽车", 0) + count
+        canonical = canonicalize(category)
+        if canonical in VEHICLE_CN:
+            bucketed[canonical] = bucketed.get(canonical, 0) + count
     return bucketed
 
 
@@ -104,7 +103,7 @@ def evaluate(
         row: dict[str, Any] = {"image": image, "parsed": pred_valid}
 
         vehicle_details: dict[str, dict[str, int]] = {}
-        for word in VEHICLE_BUCKET_WORDS:
+        for word in VEHICLE_CN:
             p, g = pred_v.get(word, 0), gt_v.get(word, 0)
             category_exact[word].append(1 if p == g else 0)
             category_ae[word].append(abs(p - g))

--- a/vlm_drive/gt.py
+++ b/vlm_drive/gt.py
@@ -1,0 +1,77 @@
+"""Build evaluation ground truth for the 50 eval images from local nuScenes tables.
+
+Reuses 04_prepare_training_data.py's conversion logic (same category map,
+same output text format) so GT and training data stay byte-compatible with
+the parser. Eval images include non-keyframe sweeps; a sweep's sample_token
+points at its owning keyframe sample, whose annotations are the nearest
+ground truth (<= 0.5s apart in nuScenes) — noted honestly in the report.
+
+Usage:
+    python -m vlm_drive gt --nuscenes data/v1.0-trainval --images data/eval_images --out data/eval_gt.json
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from .categories import NUSCENES_CATEGORY_CN
+
+NAME_CN = NUSCENES_CATEGORY_CN
+VEHICLE_NAMES = {k for k in NUSCENES_CATEGORY_CN if k.startswith("vehicle.")}
+PED_NAMES = {k for k in NUSCENES_CATEGORY_CN if k.startswith("human.")}
+SIGN_NAMES = {k for k in NUSCENES_CATEGORY_CN if k.startswith("movable_object.")}
+
+
+def build_gt(nuscenes_dir: str | Path, images_dir: str | Path, *, min_visibility: int = 1) -> dict[str, str]:
+    """min_visibility: nuScenes visibility tier 1-4 (1=0-40% ... 4=80-100%).
+    Annotations are 360°-ring truth while the model sees only CAM_FRONT;
+    raising the tier drops heavily-occluded objects and narrows that gap.
+    """
+
+    base = Path(nuscenes_dir)
+    tables = {}
+    vis_token_to_tier = {}
+    vis_path = base / "visibility.json"
+    if vis_path.exists():
+        entries = json.loads(vis_path.read_text(encoding="utf-8"))
+        def _lower_bound(entry: dict) -> int:
+            m = re.search(r"(\d+)", entry.get("description", ""))
+            return int(m.group(1)) if m else 0
+        for tier, entry in enumerate(sorted(entries, key=_lower_bound), start=1):
+            vis_token_to_tier[entry["token"]] = tier
+
+    for name in ("sample_data", "sample_annotation", "instance", "category"):
+        tables[name] = json.loads((base / f"{name}.json").read_text(encoding="utf-8"))
+
+    filename_to_sample = {Path(s["filename"]).name: s["sample_token"] for s in tables["sample_data"]}
+    inst_to_cat = {i["token"]: i["category_token"] for i in tables["instance"]}
+    cat_to_name = {c["token"]: c["name"] for c in tables["category"]}
+    ann_index: dict[str, list] = {}
+    for ann in tables["sample_annotation"]:
+        ann_index.setdefault(ann["sample_token"], []).append(ann)
+
+    gt: dict[str, str] = {}
+    for image_path in sorted(Path(images_dir).glob("*.jpg")):
+        token = filename_to_sample.get(image_path.name)
+        if not token:
+            continue
+        count_dict: dict[str, int] = {}
+        for ann in ann_index.get(token, []):
+            if vis_token_to_tier and vis_token_to_tier.get(ann.get("visibility_token", ""), 4) < min_visibility:
+                continue
+            name = cat_to_name.get(inst_to_cat.get(ann["instance_token"], ""), "")
+            if name:
+                count_dict[name] = count_dict.get(name, 0) + 1
+
+        vehicles = [f"{n}辆{NAME_CN[e]}" for e, n in count_dict.items() if e in VEHICLE_NAMES]
+        pedestrians = [f"{n}个{NAME_CN[e]}" for e, n in count_dict.items() if e in PED_NAMES]
+        cones = [NAME_CN[e] for e, n in count_dict.items() if e in SIGN_NAMES]
+
+        gt[image_path.name] = (
+            "1. 车道线：根据图片判断车道线数量和类型。\n"
+            f"2. 车辆：{'、'.join(vehicles) if vehicles else '前方无可见车辆'}。{'、'.join(pedestrians) if pedestrians else '无行人'}。\n"
+            f"3. 交通标志/信号灯：{'、'.join(cones) if cones else '无交通标志或信号灯'}。\n"
+            "4. 潜在驾驶风险：根据场景判断潜在风险。"
+        )
+    return gt

--- a/vlm_drive/parsing.py
+++ b/vlm_drive/parsing.py
@@ -37,14 +37,7 @@ _COUNT_RE = re.compile(r"(\d+)\s*[辆个只条]\s*([一-龥]+)")
 # Chinese numerals as emitted by the fine-tuned model: 三辆汽车 / 两辆卡车 / 一辆公交车
 _CN_NUM_MAP = {"一": 1, "一两": 2, "两": 2, "三": 3, "四": 4, "五": 5, "六": 6, "七": 7, "八": 8, "九": 9, "十": 10}
 _CN_COUNT_RE = re.compile(r"([一两三四五六七八九十])\s*[辆个只条]\s*([一-龥]+)")
-# Counted-object whitelist: the counting grammar is domain-specific, so a
-# count whose "category" contains no known object word (e.g. 一辆车距离约为
-# 50米 -> "车距离约为") is measurement prose, not an object count.
-_OBJECT_WORDS = ("汽车", "卡车", "公交", "巴士", "摩托", "自行", "单车", "行人", "路人", "交通锥", "锥桶", "锥")
-
-
-def _is_object_category(category: str) -> bool:
-    return any(word in category for word in _OBJECT_WORDS)
+from .categories import is_object_category as _is_object_category  # single vocabulary source
 _PEDESTRIAN_HINT = "行人"
 _VEHICLE_NONE_HINTS = ("无可见车辆", "没有车辆", "无车辆")
 _VEHICLE_PRESENT_HINTS = ("前方可见", "辆")


### PR DESCRIPTION
Why

The structured pipeline landed in #3 with three modules each carrying their own copy of the domain vocabulary, plus one spot that derived a semantic value from file order:

- parsing.py had a local object-word tuple
- evaluator.py had VEHICLE_BUCKET_WORDS and a hardcoded 汽车/车辆 alias branch
- gt.py redefined the nuScenes category map that 04_prepare_training_data.py also defines
- the visibility tier came from enumerate() order of visibility.json, silently assuming the file is sorted by percentage

Scattered copies of the same vocabulary is how the parser, evaluator, and GT builder drift apart — exactly the class of inconsistency this package exists to prevent.

What changed

- vlm_drive/categories.py is now the single source: NUSCENES_CATEGORY_CN (the 04 generator's map) with VEHICLE_CN / PEDESTRIAN_CN / SIGN_CN derived from it rather than re-listed, SURFACE_ALIASES for the fine-tuned model's observed wording (汽车/车辆/巴士/单车/锥桶/锥/路人), and canonicalize() / is_object_category() as the only entry points.
- parsing.py and evaluator.py drop their local copies and route through categories.
- gt.py imports the category map, and derives each visibility tier by parsing the percentage out of the entry's description — order-independent.
- tests: TestVocabularyConsistency pins the invariants (every alias target exists in a canonical bucket; buckets derive from the nuScenes map; prose never canonicalizes).

Validation

python -m unittest discover tests → 39 tests OK (1 skip: the real-data end-to-end test needs the local nuScenes checkout). Real-data behavior unchanged: 43/50 parse rate on the historical LoRA outputs holds, which the end-to-end test verifies when data is present.

Surface area

vlm_drive/{categories.py new, parsing.py, evaluator.py, gt.py, cli.py}, tests. No behavior change by design — this is a structure fix.

## Summary by Sourcery

Centralize domain vocabulary handling across parsing, evaluation, and ground-truth generation while preserving existing model behavior.

New Features:
- Add a shared domain-vocabulary module with canonical category names, model-output aliases, and category normalization helpers.
- Add a CLI command for generating evaluation ground truth from local nuScenes data with configurable visibility filtering.

Bug Fixes:
- Make visibility-tier assignment independent of the ordering of visibility.json entries.
- Prevent measurement prose from being interpreted as counted object categories.

Enhancements:
- Route parsing, evaluation, and ground-truth generation through a single nuScenes-backed vocabulary source to prevent category drift.

Tests:
- Add vocabulary consistency tests covering alias targets, derived category buckets, and prose handling.