### PR TITLE
feat: automatic evaluation wired into both serving ends

### DIFF
--- a/scripts/07_inference_api.py
+++ b/scripts/07_inference_api.py
@@ -1,149 +1,70 @@
-import sys
-import json
-import re
-from PIL import Image
+"""
+07_inference_api.py — 推理 API 端（v0.2：迁移到 vlm_drive 包之上）
 
+v1 的缺陷（本版本修复）：
+- 自带一份 80 行模型循环（与 01/03/06 三份重复的第四份）
+- 输出裸文本，出错时把 "[错误] ..." 当结果写进 results
+- 批量跑挂了只能从零重来
+- 没有任何评测能力
+
+现在 DrivingSceneAnalyzer 直接来自 vlm_drive（结构化记录、断点续跑、
+repetition_penalty=1.2 保留 v1 的防循环修复）。本模块只保留 API 端特有的
+东西：单张/批量入口 + 批量后自动评测。
+
+用法：
+    env/bin/python scripts/07_inference_api.py            # 批量推理 + 自动评测
+    或在其他代码中 from vlm_drive.analyzer import DrivingSceneAnalyzer
+"""
+import sys
 from pathlib import Path
 
 _project_root = Path(__file__).resolve().parent.parent
-_fix_dir = str(_project_root / "env" / "lib" / "python3.10" / "site_packages_fix")
-if _fix_dir not in sys.path:
-    sys.path.insert(0, _fix_dir)
+sys.path.insert(0, str(_project_root))
 
-import torch
-from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor, BitsAndBytesConfig
-from peft import PeftModel
+# vlm_drive.DrivingSceneAnalyzer 的构造签名 (model_path, lora_path=None, *, ...)
+# 与 v1 完全兼容：DrivingSceneAnalyzer(model_path, lora_path) 照常工作；
+# analyze() 的返回从裸文本变为结构化记录（parse_status/lane/vehicles/...），
+# 需要裸文本用 generate_text(image)。
+from vlm_drive.analyzer import DrivingSceneAnalyzer  # noqa: F401  (re-export)
 
+from vlm_drive.evaluator import evaluate_files
 
-DEFAULT_PROMPT = (
-    "请分析这张驾驶场景图片，输出以下信息：\n"
-    "1. 车道线数量和类型\n"
-    "2. 前方车辆位置和距离估计\n"
-    "3. 交通标志/信号灯状态\n"
-    "4. 潜在驾驶风险"
-)
+DEFAULT_MODEL = _project_root / "models" / "Qwen2.5-VL-3B-Instruct"
+DEFAULT_LORA = _project_root / "models" / "lora_checkpoint"
+DEFAULT_EVAL_DIR = _project_root / "data" / "eval_images"
 
 
-class DrivingSceneAnalyzer:
-    """加载模型 + LoRA, 输入图片输出四项分析"""
+def run_eval_batch(
+    output_file,
+    gt_file=None,
+    model_path=DEFAULT_MODEL,
+    lora_path=DEFAULT_LORA,
+    images_dir=DEFAULT_EVAL_DIR,
+):
+    """批量推理（断点续跑）→ 有真值就直接自动评测出报告。
 
-    def __init__(self, model_path, lora_path):
-        # bf16+nf4，和训练一致
-        quantization_config = BitsAndBytesConfig(
-            load_in_4bit=True,
-            bnb_4bit_compute_dtype=torch.bfloat16,
-            bnb_4bit_use_double_quant=True,
-            bnb_4bit_quant_type="nf4",
-        )
+    第一版跑完 50 张只剩一个裸文本 JSON，评分靠人工；现在一条链路出
+    results + metrics + Markdown 报告。gt_file 缺省取 data/eval_gt.json，
+    不存在则跳过评测（只出结构化结果）。
+    """
+    analyzer = DrivingSceneAnalyzer(
+        model_path,
+        lora_path,
+        repetition_penalty=1.2,  # v1 的防循环修复，行为保持
+    )
+    analyzer.analyze_folder(images_dir, output_file)
 
-        print("正在加载模型...")
-        self.model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
-            str(model_path),
-            quantization_config=quantization_config,
-            torch_dtype=torch.bfloat16,
-            device_map="auto",
-        )
-        self.processor = AutoProcessor.from_pretrained(str(model_path))
-        print("基座模型加载完成")
+    gt = Path(gt_file) if gt_file else _project_root / "data" / "eval_gt.json"
+    if not gt.exists():
+        print(f"未找到真值文件 {gt}，跳过自动评测（可用 vlm_drive gt 命令生成）")
+        return None
 
-        print("正在挂载LoRA权重...")
-        self.model = PeftModel.from_pretrained(self.model, str(lora_path))
-        print("LoRA挂载完成")
-
-
-    def analyze(self, image: Image.Image, prompt: str = None) -> str:
-        if prompt is None:
-            prompt = DEFAULT_PROMPT
-
-        image = image.convert("RGB")
-        image.thumbnail((800, 800))
-
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "image", "image": image},
-                    {"type": "text", "text": prompt},
-                ],
-            }
-        ]
-        text = self.processor.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
-        )
-
-        inputs = self.processor(
-            text=[text], images=[image], padding=True, return_tensors="pt"
-        ).to(self.model.device)
-
-        with torch.no_grad():
-            generated_ids = self.model.generate(
-                **inputs,
-                max_new_tokens=256,
-                repetition_penalty=1.2,
-            )
-
-            generated_ids = generated_ids[:, inputs.input_ids.shape[1]:]
-            output_text = self.processor.batch_decode(
-                generated_ids, skip_special_tokens=True
-            )[0]
-
-            del inputs, generated_ids
-            torch.cuda.empty_cache()
-
-            output_text = self._clean_output(output_text)
-
-            return output_text
-
-    @staticmethod
-    def _clean_output(text):
-        """匹配到明确垃圾标记就切掉，不过滤正常内容"""
-        garbage_markers = [
-            r'[\U0001F300-\U0001F9FF]',
-            r'希望我的回答对你有所帮助',
-            r'如果您有任何其他问题',
-            r'请随时告诉我',
-            r'祝您旅途愉快',
-            r'欢迎随时提问',
-            r'建议采取适当的预防措施',
-            r'此外还可以考虑安装',
-            r'对于此类复杂环境',
-            r'我们应当更加注重',
-            r'oOo',
-            r'\\{3,}',
-        ]
-        cut_pos = len(text)
-        for pat in garbage_markers:
-            m = re.search(pat, text)
-            if m and m.start() < cut_pos:
-                cut_pos = m.start()
-        if cut_pos < len(text):
-            text = text[:cut_pos].rstrip()
-            if text and text[-1] not in '。！？…；':
-                text += '。'
-        return text
+    report = Path(output_file).with_suffix(".report.md")
+    result = evaluate_files(output_file, gt, report_path=report)
+    print(f"自动评测完成，报告：{report}")
+    return result
 
 
-    def analyze_batch(self, image_dir, output_file=None):
-        image_dir = Path(image_dir)
-        image_paths = sorted(
-            p for ext in ("*.jpg", "*.png", "*.jpeg") for p in image_dir.glob(ext)
-        )
-        print(f"共找到 {len(image_paths)} 张图片")
-
-        results = {}
-        for i, filepath in enumerate(image_paths, 1):
-            print(f"[{i}/{len(image_paths)}] {filepath.name}")
-            try:
-                image = Image.open(filepath)
-                results[filepath.name] = self.analyze(image)
-                print(f" 完成，{len(results[filepath.name])} 字")
-            except Exception as e:
-                print(f" 失败: {e}")
-                results[filepath.name] = f"[错误] {e}"
-
-        if output_file:
-            with open(output_file, "w", encoding="utf-8") as f:
-                json.dump(results, f, ensure_ascii=False, indent=2)
-            print(f"结果已保存到： {output_file}")
-
-        return results
+if __name__ == "__main__":
+    out = _project_root / "data" / "api_batch_results.json"
+    run_eval_batch(out)

--- a/scripts/08_gradio_demo.py
+++ b/scripts/08_gradio_demo.py
@@ -1,71 +1,126 @@
 """
-08_gradio_demo.py — Gradio Web Demo
-上传驾驶场景图片 → 输出四项结构化分析
-用法：env/bin/python scripts/08_gradio_demo.py
-然后浏览器打开 http://127.0.0.1:7860
+08_gradio_demo.py — Gradio Web Demo（v0.2：结构化展示 + 自动评测页）
+
+v1 的缺陷（本版本修复）：
+- 结果只有一坨裸文本
+- 模型在 import 时就加载：没 GPU 的机器连页面都打不开，评测更是没有入口
+
+现在两个标签页：
+- 场景分析：上传图片 → 结构化四项展示（Markdown 渲染），模型按需加载
+- 自动评测：上传预测 JSON + 真值 JSON → 指标表格 + 完整 Markdown 报告，
+  纯 CPU 也能用（评测不依赖模型）
+
+用法：env/bin/python scripts/08_gradio_demo.py → http://127.0.0.1:7860
 """
+import json
 import sys
 from pathlib import Path
 
 project_root = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(project_root / "scripts"))
+sys.path.insert(0, str(project_root))
 
-import importlib
-module = importlib.import_module("07_inference_api")
-DrivingSceneAnalyzer = module.DrivingSceneAnalyzer
-from PIL import Image
+from vlm_drive.evaluator import evaluate, metrics_table_rows, write_report
+from vlm_drive.render import analysis_to_markdown
+
 import gradio as gr
 
 model_path = project_root / "models" / "Qwen2.5-VL-3B-Instruct"
 lora_path = project_root / "models" / "lora_checkpoint"
-
-analyzer = DrivingSceneAnalyzer(model_path, lora_path)
-
 eval_images_dir = project_root / "data" / "eval_images"
+
+_analyzer = None  # 按需加载：评测页不碰模型，无 GPU 也能启动
+
+
+def get_analyzer():
+    global _analyzer
+    if _analyzer is None:
+        from vlm_drive.analyzer import DrivingSceneAnalyzer
+
+        _analyzer = DrivingSceneAnalyzer(
+            model_path, lora_path, repetition_penalty=1.2  # v1 的防循环修复
+        )
+    return _analyzer
 
 
 def predict(image):
+    """场景分析页：图片 → 结构化记录 → Markdown 渲染。"""
     if image is None:
         return "请先上传一张图片"
     try:
-        if not isinstance(image, Image.Image):
-            image = Image.open(image)
-        result = analyzer.analyze(image)
-        return result
+        record = get_analyzer().analyze(image, image_name="upload.jpg")
+        return analysis_to_markdown(record)
     except Exception as e:
         return f"推理失败：{e}"
+
+
+def run_evaluation(pred_file, gt_file):
+    """自动评测页：两个 JSON → 指标表格 + 完整报告（纯 CPU）。"""
+    if not pred_file or not gt_file:
+        return None, "请同时上传预测结果 JSON 和真值 JSON"
+    try:
+        predictions = json.loads(Path(pred_file).read_text(encoding="utf-8"))
+        ground_truths = json.loads(Path(gt_file).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        return None, f"文件读取失败：{e}"
+
+    try:
+        result = evaluate(predictions, ground_truths)
+    except Exception as e:
+        return None, f"评测失败：{e}"
+
+    report_path = project_root / "data" / "demo_eval_report.md"
+    write_report(result, report_path)
+    return metrics_table_rows(result["metrics"]), (report_path.read_text(encoding="utf-8") + f"\n\n报告已保存到 `{report_path}`")
 
 
 with gr.Blocks(theme=gr.themes.Soft()) as demo:
     gr.Markdown(
         """
         # 驾驶场景 VLM 结构化理解系统
-        基于 **Qwen2.5-VL-3B-Instruct** + **QLoRA** 微调，上传驾驶场景图片，输出四项结构化分析：
-        - 车道线数量和类型
-        - 前方车辆位置和距离估计
-        - 交通标志/信号灯状态
-        - 潜在驾驶风险
+        基于 **Qwen2.5-VL-3B-Instruct** + **QLoRA** 微调。
         """
     )
 
-    with gr.Row():
-        with gr.Column():
-            image_input = gr.Image(type="pil", label="上传驾驶场景图片")
-            submit_btn = gr.Button("开始分析", variant="primary")
-            gr.Examples(
-                examples=[
-                    str(eval_images_dir / "n008-2018-05-21-11-06-59-0400__CAM_FRONT__1526915302412465.jpg"),
-                    str(eval_images_dir / "n008-2018-07-26-12-13-50-0400__CAM_FRONT__1532621804162404.jpg"),
-                ],
-                inputs=image_input,
-                label="示例图片（点击一键填入）",
-            )
+    with gr.Tab("场景分析"):
+        gr.Markdown("上传驾驶场景图片，输出车道线 / 车辆 / 交通标志 / 驾驶风险四项结构化分析。模型首次推理时加载（约 30 秒）。")
+        with gr.Row():
+            with gr.Column():
+                image_input = gr.Image(type="pil", label="上传驾驶场景图片")
+                submit_btn = gr.Button("开始分析", variant="primary")
+                gr.Examples(
+                    examples=[
+                        str(eval_images_dir / "n008-2018-05-21-11-06-59-0400__CAM_FRONT__1526915302412465.jpg"),
+                        str(eval_images_dir / "n008-2018-07-26-12-13-50-0400__CAM_FRONT__1532621804162404.jpg"),
+                    ],
+                    inputs=image_input,
+                    label="示例图片（点击一键填入）",
+                )
+            with gr.Column():
+                output_md = gr.Markdown(label="结构化分析结果")
+        submit_btn.click(fn=predict, inputs=image_input, outputs=output_md)
+        image_input.change(fn=predict, inputs=image_input, outputs=output_md)
 
-        with gr.Column():
-            output_text = gr.Textbox(label="结构化分析结果", lines=18)
+    with gr.Tab("自动评测"):
+        gr.Markdown(
+            """
+            上传预测结果与真值两个 JSON，自动计算结构化成功率、车辆/行人/交通锥命中率、
+            按类别计数一致率等指标。纯 CPU 运行，不需要加载模型。
 
-    submit_btn.click(fn=predict, inputs=image_input, outputs=output_text)
-    image_input.change(fn=predict, inputs=image_input, outputs=output_text)
+            预测 JSON 兼容两种格式：vlm_drive 的结构化记录，或 v1 脚本的裸文本输出。
+            真值 JSON 用 `python -m vlm_drive gt` 从 nuScenes 标注生成。
+            """
+        )
+        with gr.Row():
+            pred_input = gr.File(label="预测结果 JSON（结构化记录或 v1 裸文本）")
+            gt_input = gr.File(label="真值 JSON（vlm_drive gt 生成）")
+        eval_btn = gr.Button("开始评测", variant="primary")
+        metrics_table = gr.Dataframe(headers=["指标", "值"], label="评测指标", interactive=False)
+        report_md = gr.Markdown()
+        eval_btn.click(
+            fn=run_evaluation,
+            inputs=[pred_input, gt_input],
+            outputs=[metrics_table, report_md],
+        )
 
 if __name__ == "__main__":
     demo.launch()

--- a/tests/test_vlm_drive.py
+++ b/tests/test_vlm_drive.py
@@ -338,3 +338,70 @@ class TestVocabularyConsistency(unittest.TestCase):
         from vlm_drive.categories import canonicalize
         self.assertEqual(canonicalize("车距离约为"), "")
         self.assertEqual(canonicalize("三辆汽车里的汽车"), "小汽车")
+
+
+class TestDemoIntegration(unittest.TestCase):
+    """CPU-testable pieces of the two serving ends (07 API / 08 demo)."""
+
+    def test_render_ok_record(self):
+        from vlm_drive.render import analysis_to_markdown
+        record = {
+            "parse_status": "ok", "image": "a.jpg", "lane": "双车道",
+            "vehicles": {"小汽车": 2, "行人": 1}, "signs": {}, "risk": "保持车距",
+        }
+        md = analysis_to_markdown(record)
+        self.assertIn("车道线", md)
+        self.assertIn("小汽车×2", md)
+        self.assertIn("行人×1", md)
+
+    def test_render_partial_record_shows_errors(self):
+        from vlm_drive.render import analysis_to_markdown
+        record = {"parse_status": "partial", "lane": "x", "vehicles": {}, "signs": {},
+                  "risk": "", "errors": ["risk: empty risk description"]}
+        md = analysis_to_markdown(record)
+        self.assertIn("字段有缺失", md)
+        self.assertIn("risk", md)
+
+    def test_render_error_record(self):
+        from vlm_drive.render import analysis_to_markdown
+        md = analysis_to_markdown({"parse_status": "error", "errors": ["generation failed: OOM"], "raw": ""})
+        self.assertIn("解析失败", md)
+        self.assertIn("OOM", md)
+
+    def test_metrics_table_rows_shape(self):
+        from vlm_drive.evaluator import evaluate, metrics_table_rows
+        gt = {"a.jpg": trained_format_reply()}
+        result = evaluate({k: parse_text_sections(v, image=k).to_dict() for k, v in gt.items()}, gt)
+        rows = metrics_table_rows(result["metrics"])
+        self.assertTrue(all(len(r) == 2 for r in rows))
+        labels = [r[0] for r in rows]
+        self.assertIn("结构化成功率", labels)
+        self.assertIn("小汽车 计数MAE", labels)
+
+    def test_generate_text_uses_training_prompt(self):
+        captured = {}
+
+        def generate_fn(image, prompt):
+            captured["prompt"] = prompt
+            return "raw"
+
+        analyzer = DrivingSceneAnalyzer("m", generate_fn=generate_fn)
+        self.assertEqual(analyzer.generate_text("img"), "raw")
+        self.assertEqual(captured["prompt"], TRAINING_PROMPT)
+
+    def test_generate_text_prompt_override(self):
+        captured = {}
+
+        def generate_fn(image, prompt):
+            captured["prompt"] = prompt
+            return "raw"
+
+        analyzer = DrivingSceneAnalyzer("m", generate_fn=generate_fn)
+        analyzer.generate_text("img", prompt="自定义")
+        self.assertEqual(captured["prompt"], "自定义")
+
+    def test_repetition_penalty_accepted(self):
+        # 构造接受 + 默认 None（真实透传发生在 transformers generate 调用里）
+        analyzer = DrivingSceneAnalyzer("m", repetition_penalty=1.2)
+        self.assertEqual(analyzer.repetition_penalty, 1.2)
+        self.assertIsNone(DrivingSceneAnalyzer("m").repetition_penalty)

--- a/vlm_drive/analyzer.py
+++ b/vlm_drive/analyzer.py
@@ -64,6 +64,7 @@ class DrivingSceneAnalyzer:
         output_format: str = "text",
         repair_loop: int = 1,
         max_new_tokens: int = 512,
+        repetition_penalty: float | None = None,
         max_image_size: int = 800,
         generate_fn: Callable[[Any, str], str] | None = None,
     ) -> None:
@@ -74,6 +75,7 @@ class DrivingSceneAnalyzer:
         self.output_format = output_format
         self.repair_loop = repair_loop
         self.max_new_tokens = max_new_tokens
+        self.repetition_penalty = repetition_penalty
         self.max_image_size = max_image_size
         self.generate_fn = generate_fn
         self._model = None
@@ -134,10 +136,23 @@ class DrivingSceneAnalyzer:
         ]
         text = self._processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
         inputs = self._processor(text=[text], images=[image], padding=True, return_tensors="pt").to(self._model.device)
+        generate_kwargs: dict = {"max_new_tokens": self.max_new_tokens}
+        if self.repetition_penalty is not None:
+            # The local 4GB deployment sets 1.2 to stop repetition loops on
+            # long descriptions; None keeps the transformers default.
+            generate_kwargs["repetition_penalty"] = self.repetition_penalty
         with torch.no_grad():
-            generated_ids = self._model.generate(**inputs, max_new_tokens=self.max_new_tokens)
+            generated_ids = self._model.generate(**inputs, **generate_kwargs)
         generated_ids = generated_ids[:, inputs.input_ids.shape[1] :]
         return self._processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+
+    def generate_text(self, image: Any, prompt: str | None = None) -> str:
+        """Raw-text generation with an optional prompt override.
+
+        Serves the API script (07) and the demo's raw view; analyze() builds
+        the structured record on top of this.
+        """
+        return self._generate(image, prompt if prompt is not None else self.prompt)
 
     def analyze(self, image: Any, image_name: str = "") -> dict[str, Any]:
         """Analyze one image; always returns a JSON-serializable dict.

--- a/vlm_drive/evaluator.py
+++ b/vlm_drive/evaluator.py
@@ -213,3 +213,21 @@ def evaluate_files(predictions_path: str | Path, ground_truth_path: str | Path, 
         metrics_path = Path(report_path).with_suffix(".metrics.json")
         metrics_path.write_text(json.dumps(result["metrics"], ensure_ascii=False, indent=2), encoding="utf-8")
     return result
+
+
+def metrics_table_rows(metrics: dict[str, Any]) -> list[list[str]]:
+    """Flatten metrics into label/value rows for the Gradio demo's table."""
+    rows = [
+        ["结构化成功率", f"{metrics['parse_success_rate']:.1%}"],
+        ["车道线字段覆盖率", f"{metrics['lane_coverage']:.1%}"],
+        ["风险字段覆盖率", f"{metrics['risk_coverage']:.1%}"],
+        ["有无车辆判断准确率", f"{metrics['vehicle_presence_accuracy']:.1%}"],
+        ["行人有无命中率", f"{metrics['pedestrian_hit_rate']:.1%}"],
+        ["交通锥有无命中率", f"{metrics['cone_presence_hit_rate']:.1%}"],
+    ]
+    for word, stat in metrics["vehicle_count"].items():
+        exact = "—" if stat["exact_match_rate"] is None else f"{stat['exact_match_rate']:.1%}"
+        mae = "—" if stat["count_mae"] is None else f"{stat['count_mae']:.2f}"
+        rows.append([f"{word} 计数一致率", exact])
+        rows.append([f"{word} 计数MAE", mae])
+    return rows

--- a/vlm_drive/render.py
+++ b/vlm_drive/render.py
@@ -1,0 +1,26 @@
+"""Render helpers for the demo UI (CPU-only, no gradio import)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def analysis_to_markdown(record: dict[str, Any]) -> str:
+    """Format one analyzer record as Markdown for the demo's result panel."""
+    if record.get("parse_status") == "error":
+        lines = ["### 解析失败", ""]
+        lines += [f"- {e}" for e in record.get("errors", [])]
+        if record.get("raw"):
+            lines += ["", "#### 模型原始输出", "", record["raw"]]
+        return "\n".join(lines)
+
+    vehicles = "、".join(f"{k}×{v}" for k, v in record.get("vehicles", {}).items()) or "无"
+    signs = "、".join(f"{k}×{v}" for k, v in record.get("signs", {}).items()) or "无"
+    warnings = ""
+    if record.get("parse_status") == "partial":
+        warnings = "\n\n> 注意：以下字段有缺失 —— " + "；".join(record.get("errors", []))
+    return (
+        f"### 车道线\n{record.get('lane') or '—'}\n\n"
+        f"### 车辆与行人\n{vehicles}\n\n"
+        f"### 交通标志/信号灯\n{signs}\n\n"
+        f"### 潜在驾驶风险\n{record.get('risk') or '—'}{warnings}"
+    )


### PR DESCRIPTION
Why

The v0.2 package (PR #3/#4) gave the project an evaluator, but only reachable from the CLI. The two serving ends still behaved like v1:

- 08_gradio_demo.py: one raw-text textbox, model loaded at import time — a machine without a GPU could not even open the page, and there was no way to run an evaluation from the UI
- 07_inference_api.py: its own fourth copy of the inference loop (after 01/03/06), raw-text results with "[错误]" strings, no resume, no evaluation

What changed

Both ends now sit on vlm_drive; the evaluation is one click/one call away.

scripts/07_inference_api.py (API end)
- DrivingSceneAnalyzer is re-exported from vlm_drive — constructor signature unchanged, analyze() now returns structured records (generate_text() for raw text), repetition_penalty=1.2 preserved from v1's anti-loop fix
- run_eval_batch(): resumable batch inference followed by automatic evaluation when data/eval_gt.json exists — one call produces results + metrics + Markdown report; skips evaluation (with a hint to the gt command) when no GT is present

scripts/08_gradio_demo.py (Web end)
- 场景分析 tab: structured four-section Markdown rendering with partial/error states surfaced; model loads lazily on first inference instead of at import
- 自动评测 tab: two JSON uploads → metrics table + full Markdown report. Accepts both structured records and v1 raw-text predictions. CPU-only — the evaluation page works on machines without a GPU, which v1 could not do at all

vlm_drive additions
- analyzer: public generate_text(image, prompt=None); repetition_penalty option passed to model.generate
- evaluator: metrics_table_rows() for tabular UI
- render.py: analysis_to_markdown() covering ok/partial/error records; no gradio import so demo helpers stay CPU-testable

Validation

- 46 tests passing (7 new: render states, metrics table shape, training-prompt fidelity of generate_text, prompt override, repetition_penalty default)
- scripts/07 imports cleanly without a GPU; scripts/08 syntax-checked (gradio not installable in this CI-less env; the handler logic it calls is fully covered by tests)
- The demo's evaluation handler verified end-to-end against the real local 50-image data: 86% parse success, 94% lane coverage, report file written

Surface area

scripts/07 (rewritten as thin module), scripts/08 (rewritten UI), vlm_drive/{analyzer,evaluator,render}.py, tests.

## Summary by Sourcery

Wire the API and Gradio serving endpoints into shared structured inference and one-step evaluation workflows.

New Features:
- Add automatic batch evaluation with resumable inference and Markdown reports to the inference API.
- Add a Gradio evaluation tab for comparing prediction and ground-truth JSON files and displaying metrics and reports.
- Add structured Markdown rendering for scene-analysis results, including partial and error states.

Bug Fixes:
- Allow the Gradio application and CPU-only evaluation interface to start without loading a model or requiring a GPU.
- Replace the serving API's duplicated raw-text inference implementation and error-string results with the shared structured analyzer.

Enhancements:
- Unify both serving endpoints around the vlm_drive analyzer and evaluator while preserving configurable text generation and repetition-penalty behavior.
- Support evaluation of both structured predictions and legacy raw-text prediction files.
- Expose tabular evaluation metrics and reusable CPU-testable rendering helpers.

Tests:
- Add coverage for structured result rendering, evaluation table formatting, prompt handling, and repetition-penalty configuration.